### PR TITLE
SourceClear: fixes for vulnerable libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,15 +15,15 @@ compileJava {
 
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.11'
-    implementation group: 'org.mindrot', name: 'jbcrypt', version: '0.3m'
-    implementation group: 'org.springframework', name: 'spring-web', version: '3.1.1.RELEASE'
-    implementation group: 'org.apache.sling', name: 'org.apache.sling.engine', version: '2.0.4-incubator'
-    implementation group: 'org.keycloak', name: 'keycloak-saml-core', version: '1.8.1.Final'
-    implementation group: 'org.neo4j', name: 'neo4j-jmx', version: '1.3'
-    implementation group: 'com.h2database', name: 'h2', version: '1.3.176'
-    implementation group: 'org.apache.kafka', name: 'kafka_2.11', version: '0.9.0.1'
-    implementation group: 'net.bull.javamelody', name: 'javamelody-core', version: '1.59.0'
-    implementation group: 'com.orientechnologies', name: 'orientdb-server', version: '2.1.9'
+    implementation group: 'org.mindrot', name: 'jbcrypt', version: '0.4'
+    implementation group: 'org.springframework', name: 'spring-web', version: '4.3.29.RELEASE'
+    implementation group: 'org.apache.sling', name: 'org.apache.sling.engine', version: '2.4.6'
+    implementation group: 'org.keycloak', name: 'keycloak-saml-core', version: '2.5.5.Final'
+    implementation group: 'org.neo4j', name: 'neo4j-jmx', version: '3.0.0-M05'
+    implementation group: 'com.h2database', name: 'h2', version: '1.4.198'
+    implementation group: 'org.apache.kafka', name: 'kafka_2.11', version: '0.10.2.2'
+    implementation group: 'net.bull.javamelody', name: 'javamelody-core', version: '1.74.0'
+    implementation group: 'com.orientechnologies', name: 'orientdb-server', version: '2.1.11'
 }
 
-defaultTasks 'build'
+defaultTasks 'build'


### PR DESCRIPTION
This pull request was generated by SourceClear to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| GRADLE | `org.springframework:spring-web` | 3.1.1.RELEASE | 4.3.29.RELEASE | No |
| GRADLE | `org.neo4j:neo4j-jmx` | 1.3 | 3.0.0-M05 | No |
| GRADLE | `com.h2database:h2` | 1.3.176 | 1.4.198 | No |
| GRADLE | `net.bull.javamelody:javamelody-core` | 1.59.0 | 1.74.0 | No |
| GRADLE | `com.orientechnologies:orientdb-server` | 2.1.9 | 2.1.11 | No |
| GRADLE | `org.keycloak:keycloak-saml-core` | 1.8.1.Final | 2.5.5.Final | No |
| GRADLE | `org.apache.sling:org.apache.sling.engine` | 2.0.4-incubator | 2.4.6 | No |
| GRADLE | `org.apache.kafka:kafka_2.11` | 0.9.0.1 | 0.10.2.2 | No |
| GRADLE | `org.mindrot:jbcrypt` | 0.3m | 0.4 | Yes |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [SourceClear report](https://sca.analysiscenter.veracode.com/teams/E77H1bD/scans/25874309).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/reader/hHHR3gv0wYc2WbCclECf_A/root) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted SourceClear access to submit pull requests.
<!-- srcclr-pr-id-448661bfe118afb071f48220388448f9df4d8ee1a2cf83ab1d77174b0b29eef2 -->
